### PR TITLE
Update the conda env create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The easiest way to install AMBER is by ``Anaconda``. It is recommended to create
 environment for AMBER:
 
 ```
-conda create --file ./templates/conda_amber.linux_env.yml
+conda env create -f=examples/DeepSEA/conda_amber.linux_env.yml 
 python setup.py develop
 ```
 


### PR DESCRIPTION
The previous command has two problems: (1) conda create --f does not accept .yaml file (at least in the current version 4.10), and (2) the file listing the modules is not under template/. I updated the command, and please check whether this makes sense.